### PR TITLE
Fix typos, broken links, and metadata issues across 25 blog posts

### DIFF
--- a/posts/AI-Content-Labels/index.qmd
+++ b/posts/AI-Content-Labels/index.qmd
@@ -10,7 +10,7 @@ categories:
   - ChatGPT
   - OpenAI
   - Gemini
-  - Large Langauge Models
+  - Large Language Models
   - AI
   - GENAI
   - Writing

--- a/posts/Copying-a-Schema-between-SQL-Databases/index.qmd
+++ b/posts/Copying-a-Schema-between-SQL-Databases/index.qmd
@@ -15,7 +15,7 @@ categories:
 
 ## Introduction
 
-Recently, I got asked a question in passing about an approach to copying a schema's objects (including the data within those objects) to another database in Azure. This question was one that was sufficiently small enough that I could answer in a blog post in one evening but also just complex enough that I thought maybe there's a better way. So if you're looking to solve this problem then here's an evaluation of the options available to you. If you're an database/azure expert and I've missed one of the options please do share
+Recently, I got asked a question in passing about an approach to copying a schema's objects (including the data within those objects) to another database in Azure. This question was one that was sufficiently small enough that I could answer in a blog post in one evening but also just complex enough that I thought maybe there's a better way. So if you're looking to solve this problem then here's an evaluation of the options available to you. If you're a database/azure expert and I've missed one of the options please do share
 
 So to avoid this developing into Brain Crack please read this blog post and give me your thoughts
 
@@ -31,7 +31,7 @@ What we are trying to achieve:
 
 -   The database will have an undefined number of objects (so doing this manually table by table is not going to scale)
 
--   Some reconcilaltion Logging is probably a good idea.
+-   Some reconciliation logging is probably a good idea.
 
 ## Options
 
@@ -59,7 +59,7 @@ Azure Data Factory (ADF) is a cloud-based data integration service that enables 
 
 However, implementing a metadata-driven ADF approach may require more development effort compared to the other options, as it necessitates creating custom logic and understanding ADF concepts. Additionally, while ADF does provide logging capabilities, you may need to configure custom logging to achieve the desired level of reconciliation detail. Despite these drawbacks, the metadata-driven ADF approach offers a flexible and scalable solution for copying schemas between databases.
 
-## Building a Data Factory Pipeline to Copy Metdata
+## Building a Data Factory Pipeline to Copy Metadata
 
 So given the above limitations. We are forced to choose ADF in this scenario and below documents how this will be achieved.
 

--- a/posts/Getting-Started-With-Prompt-Design/index.qmd
+++ b/posts/Getting-Started-With-Prompt-Design/index.qmd
@@ -1,7 +1,7 @@
 ---
-title: " Essential Non-Technical Tools for Data Consultants"
+title: "Essential Non-Technical Tools for Data Consultants"
 author: "Scott Bell"
-description: "Essential Non-Technical Tools for technolgy Consultants that I'm currently using to help with my workflow "
+description: "Essential Non-Technical Tools for technology Consultants that I'm currently using to help with my workflow"
 date: "2023-01-03"
 draft: true
 ai-label: "No AI"

--- a/posts/Getting-Started-with-GPT-Chat/index.qmd
+++ b/posts/Getting-Started-with-GPT-Chat/index.qmd
@@ -10,7 +10,7 @@ categories:
   - ChatGPT
   - OpenAI
   - HuggingFace
-  - Large Langauge Models
+  - Large Language Models
   - AI
 ---
 
@@ -26,7 +26,7 @@ Here's a nice video on how LLMs work
 
 ## Mastering Prompt Design
 
-A well-designed prompt is essential for getting the most out of your LLM. As you go from beginner to I can make ChatGPT do exactlly what I need in the tone/style/format I require. You will learn that promp design is probably the single most important part of leveraging these LLMs (I've a whole post on this coming soon).
+A well-designed prompt is essential for getting the most out of your LLM. As you go from beginner to I can make ChatGPT do exactly what I need in the tone/style/format I require. You will learn that prompt design is probably the single most important part of leveraging these LLMs (I've a whole post on this coming soon).
 
 Here's the common sense summary of tips:
 
@@ -49,7 +49,7 @@ A pattern I've adopted and have seen others use to get around this is what I'm g
 It's a simple enough pattern, you feed your model some context and you ask it to not respond, try to reason or otherwise. You ask it to respond with just the words read/understand/acknowledge.
 
 ![](acknowledge%20priming%20pattern.png)
-This helps with separating the commands from the context. It however, doesn't guarantee you a better response or answer. It may in fact reduce the generative quality of your response but that is a story for another day (when we start looking at Malicous Prompt Injection and Security of LLMs).
+This helps with separating the commands from the context. It however, doesn't guarantee you a better response or answer. It may in fact reduce the generative quality of your response but that is a story for another day (when we start looking at Malicious Prompt Injection and Security of LLMs).
 
 ### Adopting a Persona
 

--- a/posts/Invalid-Color-Error-in-PowerShell/index.qmd
+++ b/posts/Invalid-Color-Error-in-PowerShell/index.qmd
@@ -41,7 +41,7 @@ Why does this matter? Because Azure DevOps has its own logging and theming comma
 
 ### Use a Valid Foreground Color
 
-The simplest fix is to set the console’s foreground color to a valid value before this the problematic code is called. —**Black**, **DarkBlue**, **DarkGreen**, **DarkCyan**, **DarkRed**, **DarkMagenta**, **DarkYellow**, **Gray**, **DarkGray**, **Blue**, **Green**, **Cyan**, **Red**, **Magenta**, **Yellow**, or **White**. For example, setting it to **White** is a safe bet:
+The simplest fix is to set the console’s foreground color to a valid value before the problematic code is called. —**Black**, **DarkBlue**, **DarkGreen**, **DarkCyan**, **DarkRed**, **DarkMagenta**, **DarkYellow**, **Gray**, **DarkGray**, **Blue**, **Green**, **Cyan**, **Red**, **Magenta**, **Yellow**, or **White**. For example, setting it to **White** is a safe bet:
 
 ```powershell
 [System.Console]::ForegroundColor = "White"

--- a/posts/adf-copy-activity-performance-monitoring-kql/index.qmd
+++ b/posts/adf-copy-activity-performance-monitoring-kql/index.qmd
@@ -16,9 +16,9 @@ categories:
 
 ## Introduction
 
-In Azure data orchstration, ensuring the efficient transfer of data between systems is crucial. This is where Azure Data Factory (ADF) and Azure Synapse Analytics shine. Recently, I had to perform analysis on a misbehaving copy activity in ADF. I figured I'd provide  my query here as a form of my repeated attemps at D-R-Y 
+In Azure data orchestration, ensuring the efficient transfer of data between systems is crucial. This is where Azure Data Factory (ADF) and Azure Synapse Analytics shine. Recently, I had to perform analysis on a misbehaving copy activity in ADF. I figured I'd provide my query here as a form of my repeated attempts at D-R-Y 
 
-For this example the pipeline is named **Copy My Data**, leverages a self-hosted integration runtime to demostrate addtional filtering in the query
+For this example the pipeline is named **Copy My Data**, leverages a self-hosted integration runtime to demonstrate additional filtering in the query
 
 In this blog post, I'll demonstrate how to monitor and analyze the performance of this ADF pipeline, focusing on the ADF copy activity. We'll utilize the **ADFActivityRun** logs and Kusto Query Language (KQL) to extract meaningful insights and ensure our data processes are running efficiently.
 
@@ -78,7 +78,7 @@ For more granular insights, consider the following additional filters:
   | where sql_query contains "TABLE"
   ```
 
-- **Filter by Intergration Runtime Used in the Copy**:
+- **Filter by Integration Runtime Used in the Copy**:
   ```kql
   | where EffectiveIntegrationRuntime == "MY-Self_hosted-IR"
   ```

--- a/posts/agentic-decomposition/index.qmd
+++ b/posts/agentic-decomposition/index.qmd
@@ -61,7 +61,7 @@ Walk through the workflow and identify every point where a decision must be made
 -   **Quality decisions:** Is this output good enough?
 -   **Recovery decisions:** Something failed... what now?
 
-Each significant decision point is a candidate for agent involvement. Agents are strocastic (don't forget that part!)decision makers with context.
+Each significant decision point is a candidate for agent involvement. Agents are stochastic (don't forget that part!) decision makers with context.
 
 ### Step 3: Identify Natural Boundaries
 
@@ -97,7 +97,7 @@ This is where my [layered diagramming approach](../agentic-diagramming/index.qmd
 
 
 
-## CommonDecomposition Patterns
+## Common Decomposition Patterns
 
 There are several patterns that have been noted by those (including myself) in the Agentic AI world. Below are the main ones to consider.
 

--- a/posts/agentic-diagramming/index.qmd
+++ b/posts/agentic-diagramming/index.qmd
@@ -66,13 +66,13 @@ Every agent is a node. Every possible interaction is an arrow. The diagram is te
 -   What happens when things go wrong?
 
 
-Okay maybe that example is a bit a hyperbolic but you hopefully get the point.
+Okay maybe that example is a bit hyperbolic but you hopefully get the point.
 
 ## Layered Agentic Visualization
 
 Here's my approach (framework?) for creating agentic diagrams.
 
-What we are trying to commuicate is this
+What we are trying to communicate is this
 
 ![](images/Intelligent%20Agent%20Framework.svg)
 
@@ -80,7 +80,7 @@ What we are trying to commuicate is this
 
 Start with a high-level overview that answers: "What agents exist, and what can they do?"
 
-Shout out to [Tori Tompkins](https://toritompkins.co.uk/) who showed a really good example of this too me recently.
+Shout out to [Tori Tompkins](https://toritompkins.co.uk/) who showed a really good example of this to me recently.
 
 ![](images/agentic-capability.png)
 

--- a/posts/agentic-patterns-right-now-2025 copy/index.qmd
+++ b/posts/agentic-patterns-right-now-2025 copy/index.qmd
@@ -2,7 +2,7 @@
 title: "AI Patterns I'm exploring right now"
 subtitle: "From Augmentation to Orchestration (and Why Context Is the Real Battleground)"
 author: "Scott Bell"
-date: "2025-30-12"
+date: "2025-12-30"
 draft: true
 categories: 
   - LLMs
@@ -10,7 +10,7 @@ categories:
   - ChatGPT
   - OpenAI
   - Gemini
-  - Large Langauge Models
+  - Large Language Models
   - AI
   - GENAI
   - ai-augmented-coding
@@ -179,7 +179,9 @@ This is where cost and token efficiency may start to matter:
 -   Often “good enough” for bounded tasks
 
 Yes, sometimes they’re sloppy.\
-But there are ways of engineerign around that. ---
+But there are ways of engineering around that.
+
+---
 
 ## Trend 5: Small Language Models aren’t a step backwards
 
@@ -218,7 +220,7 @@ You can often:
 -   Reduce hallucination
 -   Improve consistency
 -   Make behaviour easier to reason.
--   Make the feedback loop from the LLM's output too testing tools tighter
+-   Make the feedback loop from the LLM's output to testing tools tighter
 
 A former colleague James Randall has been experimenting with constrained generation (GBNF). See his fascinating write-up here https://www.jamesdrandall.com/posts/gbnf-constrained-generation/
 
@@ -235,7 +237,7 @@ Is it useful? Potentially very.
 
 Some people believe:
 
-> The smallest *well-constrained* fine-train model can outperform a much larger one in the right domain.
+> The smallest *well-constrained* fine-tuned model can outperform a much larger one in the right domain.
 
 That idea is still being tested — but it’s not fringe anymore.
 

--- a/posts/agentic-security-risks/index.qmd
+++ b/posts/agentic-security-risks/index.qmd
@@ -195,7 +195,7 @@ Successful attacks against agents follow a consistent pattern:
 
 [Johann Rehberger](https://embracethered.com/blog/) has documented this against Claude Code, GitHub Copilot, Amazon Q, and Gemini. The pattern is reliable because these machines are so unreliable. 
 
-The main defence against these types of attack are Guardrails. And well... Guardrails are effectively a "please don't do this" mechanism which as we know totally will wotk 100% of time when you're working with Stochastic Models...
+The main defence against these types of attack are Guardrails. And well... Guardrails are effectively a "please don't do this" mechanism which as we know totally will work 100% of the time when you're working with Stochastic Models...
 
 
 ## A Timely Example

--- a/posts/agentic-security-risks/index.qmd
+++ b/posts/agentic-security-risks/index.qmd
@@ -195,7 +195,7 @@ Successful attacks against agents follow a consistent pattern:
 
 [Johann Rehberger](https://embracethered.com/blog/) has documented this against Claude Code, GitHub Copilot, Amazon Q, and Gemini. The pattern is reliable because these machines are so unreliable. 
 
-The main defence against these types of attack are Guardrails. And well... Guardrails are effectively a "please don't do this" mechanism which as we know totally will work 100% of the time when you're working with Stochastic Models...
+The main defences against these types of attack are Guardrails. And well... Guardrails are effectively a "please don't do this" mechanism which as we know totally will work 100% of the time when you're working with Stochastic Models...
 
 
 ## A Timely Example

--- a/posts/agentic-workflow/index.qmd
+++ b/posts/agentic-workflow/index.qmd
@@ -2,7 +2,7 @@
 title: "AI Patterns I'm exploring right now"
 subtitle: "From Augmentation to Orchestration (and Why Context Is the Real Battleground)"
 author: "Scott Bell"
-date: "2025-30-12"
+date: "2025-12-30"
 draft: true
 categories: 
   - LLMs
@@ -10,7 +10,7 @@ categories:
   - ChatGPT
   - OpenAI
   - Gemini
-  - Large Langauge Models
+  - Large Language Models
   - AI
   - GENAI
   - ai-augmented-coding
@@ -179,7 +179,9 @@ This is where cost and token efficiency may start to matter:
 -   Often “good enough” for bounded tasks
 
 Yes, sometimes they’re sloppy.\
-But there are ways of engineerign around that. ---
+But there are ways of engineering around that.
+
+---
 
 ## Trend 5: Small Language Models aren’t a step backwards
 
@@ -218,7 +220,7 @@ You can often:
 -   Reduce hallucination
 -   Improve consistency
 -   Make behaviour easier to reason.
--   Make the feedback loop from the LLM's output too testing tools tighter
+-   Make the feedback loop from the LLM's output to testing tools tighter
 
 A former colleague James Randall has been experimenting with constrained generation (GBNF). See his fascinating write-up here https://www.jamesdrandall.com/posts/gbnf-constrained-generation/
 
@@ -235,7 +237,7 @@ Is it useful? Potentially very.
 
 Some people believe:
 
-> The smallest *well-constrained* fine-train model can outperform a much larger one in the right domain.
+> The smallest *well-constrained* fine-tuned model can outperform a much larger one in the right domain.
 
 That idea is still being tested — but it’s not fringe anymore.
 

--- a/posts/aiops-journey-four-threat-quadrants/index.qmd
+++ b/posts/aiops-journey-four-threat-quadrants/index.qmd
@@ -24,7 +24,7 @@ If your AI risk strategy begins and ends with "what could AI do to us," you're o
 
 Yet most organizations approach AI risk one-dimensionally.
 
-They focus on the obvious hallucinations, bias, deepfakes aka the threats that **AI systems pose to us**. That's important, but it's only one quadrant of the picture. What about threats directed **at your AI systems**? What about the **risk of not adopting AI** while competitors race ahead? What about the **liability from your own AI adoption** creates?
+They focus on the obvious hallucinations, bias, deepfakes aka the threats that **AI systems pose to us**. That's important, but it's only one quadrant of the picture. What about threats directed **at your AI systems**? What about the **risk of not adopting AI** while competitors race ahead? What about the **liability your own AI adoption** creates?
 
 These aren't edge cases. They're the other 75% of your risk landscape that goes unmanaged when you treat AI risk as a single category.
 
@@ -50,7 +50,7 @@ Frameworks like [MITRE ATLAS](https://atlas.mitre.org/) provide a structured tax
 
 There's a risk to inaction. Organizations that fail to adopt AI effectively face competitive disadvantage, operational inefficiency, and missed opportunities. While your competitors use AI to accelerate product development, improve customer experience, and optimize operations, standing still means falling behind.
 
-The McKinsey data on the gap between AI adoption and AI value is telling here. The organiations seeing real returns aren't just experimenting with AI. They're operationalising it effectively. They're redesigning workflows, not just adding AI as a feature.
+The McKinsey data on the gap between AI adoption and AI value is telling here. The organisations seeing real returns aren't just experimenting with AI. They're operationalising it effectively. They're redesigning workflows, not just adding AI as a feature.
 
 ## Threats USING AI Models
 

--- a/posts/aiops-journey-what-is-it/index.qmd
+++ b/posts/aiops-journey-what-is-it/index.qmd
@@ -21,7 +21,7 @@ So over the coming months we are going to start talking about these challenges, 
 
 ## The Ops Landscape: Where We Are Today
 
-The AI space is moving at a pace that makes traditional software development look glacial. New tool, models and frameworks emerge monthly. Best practices from six months ago are already outdated. And yet, organizations are being pushed to adopt AI faster than ever.
+The AI space is moving at a pace that makes traditional software development look glacial. New tools, models and frameworks emerge monthly. Best practices from six months ago are already outdated. And yet, organizations are being pushed to adopt AI faster than ever.
 
 According to [McKinsey's State of AI 2025 report](https://www.mckinsey.com/capabilities/quantumblack/our-insights/the-state-of-ai), 88% of companies now use AI regularly in at least one function, up from 78% the previous year. That sounds like progress. But dig deeper and a troubling picture emerges: only 39% report meaningful EBIT impact at the enterprise level. Just one-third have begun scaling their AI programs beyond pilot projects.
 
@@ -38,7 +38,7 @@ The gap between AI adoption and AI value is widening. A significant part of that
 The top four points that stand out:
 
 1.  **69% agree the culture of their organisation enables AI adoption** - Culture is foundational. Without leadership buy-in and a willingness to experiment, even the best technology investments stall.
-2.  **66% agree their technology environment enables AI integration** - Having the infrastructure to actually deploy and integrate AI is important. A third of organisations survey'd are still fighting this battle.
+2.  **66% agree their technology environment enables AI integration** - Having the infrastructure to actually deploy and integrate AI is important. A third of organisations surveyed are still fighting this battle.
 3.  **Only 51% have a clearly defined roadmap for AI initiatives** - Without strategic direction, AI becomes a collection of disconnected experiments.
 4.  **Only 51% have formalised Responsible AI processes** - Governance gaps create compliance risk and erode trust.
 
@@ -150,7 +150,7 @@ Over the course of this blog series, we'll explore the foundational pillars that
 
 **Monitoring & Observability** - Understanding what your AI systems are doing in production. Beyond traditional metrics, this includes monitoring for drift, hallucinations, bias, and emergent behaviors.
 
-**Cost Management** - AI Financial Ops (FinOps) is going to be a key theme in 20206 and beyond. AI workloads, especially generative AI, can have unpredictable and significant costs. Effective operations require visibility and control over compute, API, and data costs.
+**Cost Management** - AI Financial Ops (FinOps) is going to be a key theme in 2026 and beyond. AI workloads, especially generative AI, can have unpredictable and significant costs. Effective operations require visibility and control over compute, API, and data costs.
 
 **Team Structure & Skills** - Building the organizational capability to operate AI effectively. This includes roles, skills development, and the cultural changes needed to work with non-deterministic systems.
 

--- a/posts/building-quarto-on-github/index.qmd
+++ b/posts/building-quarto-on-github/index.qmd
@@ -19,7 +19,7 @@ categories:
 
 [Part 2](https://www.myyearindata.com/posts/building-quarto-on-github/)
 
-Part 3 (Coming Soon)
+[Part 3](https://www.myyearindata.com/posts/deploying-to-azure-static-web-apps/)
 :::
 
 ## Introduction
@@ -36,7 +36,7 @@ You will no longer need to store any rendered documents in your repository eithe
 
 ## Installing Quarto via the command line
 
-The official Posit site (whom created) Quarto website discusses [how you can download quarto and install it on Linux using a .deb file.](https://docs.posit.co/resources/install-quarto/) We will use this to install Posit onto our Machine within Github Workflows.
+The official Posit site (who created) Quarto website discusses [how you can download quarto and install it on Linux using a .deb file.](https://docs.posit.co/resources/install-quarto/) We will use this to install Posit onto our Machine within Github Workflows.
 
 1.  First we will need to set up our job. This involves the checking out of the code (so we can use it to render our site).
 
@@ -74,7 +74,7 @@ jobs:
       run: quarto render
 ```
 
-7.  We can now upload our file as an artfact from our github workflow for later consumption in other workflows (e.g upload to web or local file storage etc) or should you wish you can download a full zip manually. Below shows you how to upload a \_site directory for a rendered website, you can adjust as you require.
+7.  We can now upload our file as an artifact from our github workflow for later consumption in other workflows (e.g upload to web or local file storage etc) or should you wish you can download a full zip manually. Below shows you how to upload a \_site directory for a rendered website, you can adjust as you require.
 
 ``` yaml
 

--- a/posts/data-intelligence-engineer/index.qmd
+++ b/posts/data-intelligence-engineer/index.qmd
@@ -34,7 +34,7 @@ At **SQLBITS 2025**, the contrast between my session and Simon's could not have 
 {{< video https://www.youtube.com/watch?v=tV_hmSp5-g8 >}}
 :::
 
-This isn't just a topic for a conference talk. I have been using ChatGPT since its first day. I've become a very adept [prompt engineer]() and see significant productivity gains in my personal and professional life from these models. AI augmentation of our daily workflows is the future, and its strengths in pattern recognition, code generation, and summarizing information are obvious. The real question is how we integrate it effectively.
+This isn't just a topic for a conference talk. I have been using ChatGPT since its first day. I've become a very adept prompt engineer and see significant productivity gains in my personal and professional life from these models. AI augmentation of our daily workflows is the future, and its strengths in pattern recognition, code generation, and summarizing information are obvious. The real question is how we integrate it effectively.
 
 ## The Engineering Evolution: From Stored Procedures to Accelerators
 
@@ -43,9 +43,9 @@ To understand where we're going, we need to look at where we've been. Many data 
 Then, we moved to cloud data platforms like Databricks. This shift introduced notebooks and encouraged teams to build reusable functions and, eventually proper internal frameworks. It was a certainly an improvement for **most**.
 
 ::: {.callout-warning appearance="simple"}
-## 
+## A Simplified Timeline
 
-There's lot of context I'm missing here I know. The Data Warehouse architecture battles, Vendor Wars, Hadoop, Sqoop, Azure Data Lake Analytics. Early Orchstrators such as SSIS, ADFv1 and more. It doesn't add value to the point I'm making, so I'm simplifying the timeline.
+There's a lot of context I'm missing here I know. The Data Warehouse architecture battles, Vendor Wars, Hadoop, Sqoop, Azure Data Lake Analytics. Early Orchestrators such as SSIS, ADFv1 and more. It doesn't add value to the point I'm making, so I'm simplifying the timeline.
 :::
 
 The more recent trend was building solution or platform accelerators. These tools focus on enabling data engineers and scientists to do their best work by abstracting away boilerplate code. The idea is sound: let engineers focus on the business context and problem-solving, not rewriting the same data-loading script for the hundredth time. This is often achieved through [Configuration-as-Code](https://configu.com/blog/what-is-configuration-as-code-cac-and-5-tips-for-success/) (CaC), where you define your pipelines in a structured format like YAML, JSON or SQL Tables.
@@ -85,7 +85,7 @@ Of course, this transition isn't without friction. As [Birgitta Böckeler, a Dis
 The challenge, then, is to be intentional. We must strive to be augmented coders while managing the technical debt we accrue. The solution to these risks is the same as the solution to the security points I made in my SQLBITS talk. We need a combination of three things:
 
 1.  **Strategy:** Clear guidelines on expectations, accountability and governance.
-2.  **Education:** Training engineers to be augmented coders, not vibe coders. This means teaching them how to prompt effectively, spot bad output, and understand limitations. Also ensuring they still learn via first principals and develop understanding of their field i.e. design patterns or kimball modelling.
+2.  **Education:** Training engineers to be augmented coders, not vibe coders. This means teaching them how to prompt effectively, spot bad output, and understand limitations. Also ensuring they still learn via first principles and develop understanding of their field i.e. design patterns or kimball modelling.
 3.  **Awareness:** A constant conversation about what works, what doesn't, and how to apply these systems responsibly.
 
 These are the tools that will allow us to truly benefit from LLMs. They are what will let us become what Simon calls the "Data Intelligence Engineer." It's a title that captures the shift from just building pipelines to integrating intelligent systems into our work.

--- a/posts/deploying-azure-static-web-app-based-quarto-blog/index.qmd
+++ b/posts/deploying-azure-static-web-app-based-quarto-blog/index.qmd
@@ -18,7 +18,7 @@ categories:
 
 [Part 2](https://www.myyearindata.com/posts/building-quarto-on-github/)
 
-Part 3 (Coming Soon)
+[Part 3](https://www.myyearindata.com/posts/deploying-to-azure-static-web-apps/)
 
 :::
 ## The Setup
@@ -31,11 +31,11 @@ I choose [Quarto](https://quarto.org/) to achieve this. I have used RMarkdown (Q
 
 > Quarto^®^ is an open-source scientific and technical publishing system built on [Pandoc](https://pandoc.org/)
 
-It effectively is an extension of Markdown with the ability to embed code, similar to say IPython/Juypter Notebook tools but less of a Kernel and more of a publishing tool. It supports pretty much any language or markdown tool but I’m primarily using the RStudio Visual Editor Experience while writing this blog.
+It effectively is an extension of Markdown with the ability to embed code, similar to say IPython/Jupyter Notebook tools but less of a Kernel and more of a publishing tool. It supports pretty much any language or markdown tool but I’m primarily using the RStudio Visual Editor Experience while writing this blog.
 
 One of the main benefits of using Quarto is that it allows you to create fully reproducible documents. This means that someone else can take your document and re-run the code to get the same results, ensuring the transparency and integrity of your work.
 
-So with this choice selected, I knew I needed to host the static output somewhere. The Quarto page has some good guides on using popular frameworks like Netify or Github Pages but I wanted to use Azure.
+So with this choice selected, I knew I needed to host the static output somewhere. The Quarto page has some good guides on using popular frameworks like Netlify or Github Pages but I wanted to use Azure.
 
 #### Azure Static Web Apps
 

--- a/posts/deploying-to-azure-static-web-apps/index.qmd
+++ b/posts/deploying-to-azure-static-web-apps/index.qmd
@@ -27,9 +27,9 @@ This is [part 3 of a 3 part series](https://www.myyearindata.com/#category=quart
 
 So far in our adventure, I've explained how you set up Azure Static Web Apps and the wider set-up of Quarto on Github.
 
-##Creating an Azure Static Web App
+## Creating an Azure Static Web App
 
-First, you're going to need to provision an Azure Static Web App instance. The [Microsoft Docs](https://learn.microsoft.com/en-us/azure/static-web-apps/get-started-portal?tabs=vanilla-javascript&pivots=github) are really good for this so follow those insrtuctions.
+First, you're going to need to provision an Azure Static Web App instance. The [Microsoft Docs](https://learn.microsoft.com/en-us/azure/static-web-apps/get-started-portal?tabs=vanilla-javascript&pivots=github) are really good for this so follow those instructions.
 
 ## Prerequisite Step: Render Quarto Markdown Website
 
@@ -37,9 +37,9 @@ First, you're going to need to provision an Azure Static Web App instance. The [
 
 ## Deployment Workflow
 
-To acheive the deployment we are going to use a collection of github actions in a workflow which are explained in this section. Addtionally, we will only use the action to run on the main branch so that we can use feature branching (mentioned in part 1).
+To achieve the deployment we are going to use a collection of github actions in a workflow which are explained in this section. Additionally, we will only use the action to run on the main branch so that we can use feature branching (mentioned in part 1).
 
-The Azure Static Web action is referenced below and it's offical docs are [here](https://github.com/Azure/static-web-apps-deploy)
+The Azure Static Web action is referenced below and its official docs are [here](https://github.com/Azure/static-web-apps-deploy)
 
 ``` json
   deploy_to_azure_static_webapp:

--- a/posts/handling-uk-bank-holidays-in-adf-pipelines/index.qmd
+++ b/posts/handling-uk-bank-holidays-in-adf-pipelines/index.qmd
@@ -17,11 +17,11 @@ categories:
 
 Sometimes you have processes that you don't need to run in certain scenarios. The past year I've been working with market trading data. Trading in exchanges happens every weekday but they don't happen on weekends or national holidays as they're usually closed.
 
-This posses a problem to usual ADF trigger patterns where you can [schedule quite complex trigger](https://learn.microsoft.com/en-us/azure/data-factory/how-to-create-schedule-trigger?tabs=data-factory)scenarios such as the 1st Sunday of every month. However, no concept of national holidays exist, so we need to handle this after the trigger point.
+This poses a problem to usual ADF trigger patterns where you can [schedule quite complex trigger](https://learn.microsoft.com/en-us/azure/data-factory/how-to-create-schedule-trigger?tabs=data-factory)scenarios such as the 1st Sunday of every month. However, no concept of national holidays exist, so we need to handle this after the trigger point.
 
 ## Problem
 
-So lets restate the problem within the context of ADF. We need to trigger our process everyday, then **we must validate whether this date is a UK Bank Holiday** and run the business logic.
+So let's restate the problem within the context of ADF. We need to trigger our process everyday, then **we must validate whether this date is a UK Bank Holiday** and run the business logic.
 
 ## Solution
 

--- a/posts/obsidian-second-brain-ai-agents/index.qmd
+++ b/posts/obsidian-second-brain-ai-agents/index.qmd
@@ -105,7 +105,7 @@ AI agents built into cloud apps will always be sub-par compared to state of the 
 <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 ```
 
-*The Creator of Obsidan*
+*The Creator of Obsidian*
 
 ## When AI Agents Tip the Value Equation
 
@@ -159,7 +159,7 @@ The process is asynchronous. I queue up research tasks in the morning, and by af
 
 This is the unglamorous agent. It scans for uncataloged notes (no tags, missing metadata, orphaned from the graph). It suggests tags based on content analysis. It identifies broken links. It flags notes I haven't touched in months that might be stale or outdated.
 
-I run it weekly. It generates a report of vault health issues, fixes most auotmatically and I spend 30 minutes cleaning up anything else. Without this agent, the vault would slowly decay into an unsearchable mess.
+I run it weekly. It generates a report of vault health issues, fixes most automatically and I spend 30 minutes cleaning up anything else. Without this agent, the vault would slowly decay into an unsearchable mess.
 
 ### Agent 3: Goal Alignment Agent
 
@@ -199,11 +199,13 @@ I also use it for content generation. Writing this post, I queried my vault for 
 
 This agent is only as good as the notes you've written. Garbage in, garbage out. If you don't write clear, well-structured notes, the retrieval won't be useful. But if you maintain decent notes, the experience of asking your own knowledge base questions and getting thoughtful answers is remarkable.
 
-As I wrote in my [agentic patterns post](../agentic-patterns-right-now-2025/index.qmd), the shift from retention to retrieval is fundamental. You don't need to remember everything. You need to be able to find and use what you've captured. This agent makes that practical. Personal Knowledge Management as an Agentic Pattern
+As I wrote in my [agentic patterns post](../agentic-patterns-right-now-2025/index.qmd), the shift from retention to retrieval is fundamental. You don't need to remember everything. You need to be able to find and use what you've captured. This agent makes that practical.
+
+## Personal Knowledge Management as an Agentic Pattern
 
 Both knowledge graphs and agentic AI have hype problems. Knowledge graphs were supposed to revolutionize how we think. Agentic AI is supposed to replace knowledge workers. Most of the hype is nonsense.
 
-But both deliver real utility to you **a human** when you actually do the work.
+But both deliver real utility to you, **a human**, when you actually do the work.
 
 **Looking forward:**
 

--- a/posts/spcolumns-metadata-activities-in-data-factory-copy-activities-and-calculated-columns/index.qmd
+++ b/posts/spcolumns-metadata-activities-in-data-factory-copy-activities-and-calculated-columns/index.qmd
@@ -24,7 +24,7 @@ Well no, firstly the table definition existed in the target DB, which given that
 
 The first thing that comes to mind is [GET Metadata activity in ADF](https://learn.microsoft.com/en-us/azure/data-factory/connector-azure-sql-database?tabs=data-factory#getmetadata-activity-properties). Sadly that doesn't have sufficient detail about the column definitions.
 
-The next thought was the [stored procedure sp_columns](https://learn.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sp-columns-transact-sql?view=sql-server-ver16) which returns metadata about columns and is a tool I'd imagine almost all data engineers use in the their SQL development workflow. So that's what I did, using the (relatively) new [script activity](https://learn.microsoft.com/en-us/azure/data-factory/transform-data-using-script) in ADF.
+The next thought was the [stored procedure sp_columns](https://learn.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sp-columns-transact-sql?view=sql-server-ver16) which returns metadata about columns and is a tool I'd imagine almost all data engineers use in their SQL development workflow. So that's what I did, using the (relatively) new [script activity](https://learn.microsoft.com/en-us/azure/data-factory/transform-data-using-script) in ADF.
 
 ## Solution
 

--- a/posts/sql-bits-2025/index.qmd
+++ b/posts/sql-bits-2025/index.qmd
@@ -8,14 +8,14 @@ categories:
   - meta
   - personal 
   - conference 
-  - -sqlbits
+  - sqlbits
 ---
 
 ::: {.callout-note appearance="simple"}
 This was generated with the help of AI based on my research. See my post on [AI Content Labels](../AI-Content-Labels/index.qmd)
 :::
 
-So incase you didn't know I attended SQLBITS 2025 last month and presented a talk entitled Danger In Dialogue: The Security Risks of Large Language Models.
+So in case you didn't know I attended SQLBITS 2025 last month and presented a talk entitled Danger In Dialogue: The Security Risks of Large Language Models.
 
 ::: {.callout-tip appearance="simple" collapse="true"}
 ## Danger In Dialogue: The Security Risks of Large Language Models
@@ -40,4 +40,4 @@ You will see a slow drip feed of posts over the next few days. For now I'd like 
 
 [I don't want my career to DIE. The Data Intelligence Engineer or the difference between Vibe Coding and Augmented Coding.](../data-intelligence-engineer/index.qmd)
 
-[Creating a SQLBits trailer with VEO3: Lessons Learnt]()
+[Creating a SQLBits trailer with VEO3: Lessons Learnt](../veo3-sqlbits-trailer/index.qmd)

--- a/posts/tools-for-consultants/index.qmd
+++ b/posts/tools-for-consultants/index.qmd
@@ -23,7 +23,7 @@ Taking good notes is hard, taking them while you're familiarizing yourself withi
 
 When you're a senior team member, you're often in a lot of meetings about a lot of things with a lot of different stakeholders. That causes problems, namely **context switching** and that comes at a cost. Previously, I've used tools like Microsoft OneNote to take notes, it integrates with Office, it syncs across devices and it's usually protected by your company's data protection policies. It's pretty good but it doesn't quite fit my workflow.
 
-For the last year or so I've been using a tool called [StashPad](https://docs.stashpad.com/) for most of my note taking. It gives you a nice little buckets of information, where you can nest, tag and build a structure around your brain dumps.
+For the last year or so I've been using a tool called [StashPad](https://docs.stashpad.com/) for most of my note taking. It gives you nice little buckets of information, where you can nest, tag and build a structure around your brain dumps.
 
 I leave a meeting, I make sure my notes are committed to a bucket, I enable features like timestamping so I can come back and review that knowledge. Most importantly it supports markdown for custom formatting.
 

--- a/posts/tools-for-consultants/index.qmd
+++ b/posts/tools-for-consultants/index.qmd
@@ -17,13 +17,13 @@ As a consultant, you know the importance of having the right tools in your arsen
 
 ### Note taking
 
-Taking good notes is hard, taking them while your familiarizing yourself within a team, client or domain feels nigh impossible often. A lot of what I do nowadays is writing and designing things so that it enables others to go away and build them. Trapping that knowledge up in my head doesn't benefit my wider team and to be honest it's a little lazy.
+Taking good notes is hard, taking them while you're familiarizing yourself within a team, client or domain feels nigh impossible often. A lot of what I do nowadays is writing and designing things so that it enables others to go away and build them. Trapping that knowledge up in my head doesn't benefit my wider team and to be honest it's a little lazy.
 
 ![](jim-meme.jpg){fig-align="center"}
 
-When you're an senior team member, you're often in a lot of meetings about a lot of things with a lot of different stakeholders. That causes problems, namely **context switching** and that comes at a cost. Previously, I've used tools like Microsoft OneNote to take notes, it's integrates with Office, it syncs across devices and it's usually protected by your companies data protection policies. It's pretty good but it doesn't quite fit my workflow.
+When you're a senior team member, you're often in a lot of meetings about a lot of things with a lot of different stakeholders. That causes problems, namely **context switching** and that comes at a cost. Previously, I've used tools like Microsoft OneNote to take notes, it integrates with Office, it syncs across devices and it's usually protected by your company's data protection policies. It's pretty good but it doesn't quite fit my workflow.
 
-For the last year or so I've been using a tool called [StashPad](https://docs.stashpad.com/)for most of my noting taking. It gives you a nice little buckets of information, where you can nest, tag and build a structure around your brain dumps.
+For the last year or so I've been using a tool called [StashPad](https://docs.stashpad.com/) for most of my note taking. It gives you a nice little buckets of information, where you can nest, tag and build a structure around your brain dumps.
 
 I leave a meeting, I make sure my notes are committed to a bucket, I enable features like timestamping so I can come back and review that knowledge. Most importantly it supports markdown for custom formatting.
 
@@ -35,7 +35,7 @@ It works really well for 1-2-1 meetings too.
 
 [GoodNotes](https://www.goodnotes.com/) is a note-taking app designed specifically for the iPad, and it allows you to do much more than just jotting down your thoughts. With its versatile features and seamless integration with the Apple Pencil 2, it has become an indispensable part of my daily routine. Drawing concepts, rough architectures or explanatory diagrams are all what I use it for now!
 
-The app's allows you to create notebooks for different projects or meetings, and then organize them into folders or categories as needed. GoodNotes supports handwriting recognition, which means you can write naturally with the Apple Pencil and then convert your handwritten notes into text later. This feature is particularly useful when you're in a meeting and need to take quick, legible notes without having to worry about typing.
+The app allows you to create notebooks for different projects or meetings, and then organize them into folders or categories as needed. GoodNotes supports handwriting recognition, which means you can write naturally with the Apple Pencil and then convert your handwritten notes into text later. This feature is particularly useful when you're in a meeting and need to take quick, legible notes without having to worry about typing.
 
 ##### Customizable Collections of Images
 
@@ -45,7 +45,7 @@ One of the standout features of GoodNotes is its ability to customize collection
 
 ### Greenshot
 
-Screenshots are an incredibly useful way to capture and share information quickly. Whether you're demonstrating a bug, sharing a design concept, or providing feedback on a document.This is where [Greenshot](https://getgreenshot.org/)comes in. Greenshot is a lightweight, open-source screenshot tool that allows you to easily capture your screen or a specific area and **annotate**, **highlight**, or **obfuscate** parts of the image.
+Screenshots are an incredibly useful way to capture and share information quickly. Whether you're demonstrating a bug, sharing a design concept, or providing feedback on a document. This is where [Greenshot](https://getgreenshot.org/) comes in. Greenshot is a lightweight, open-source screenshot tool that allows you to easily capture your screen or a specific area and **annotate**, **highlight**, or **obfuscate** parts of the image.
 
 What sets Greenshot apart from other screenshot tools is its simplicity and ease of use. With a few clicks, you can capture the perfect screenshot, annotate it to add context, and share it with your team.
 

--- a/posts/veo3-sqlbits-trailer/index.qmd
+++ b/posts/veo3-sqlbits-trailer/index.qmd
@@ -15,7 +15,7 @@ categories:
 This was generated with the help of AI based on my research. See my post on [AI Content Labels](../AI-Content-Labels/index.qmd)
 :::
 
-So incase you didn't know I attended SQLBITS 2025 earlier this year and presented a talk entitled Danger In Dialogue: The Security Risks of Large Language Models.
+So in case you didn't know I attended SQLBITS 2025 earlier this year and presented a talk entitled Danger In Dialogue: The Security Risks of Large Language Models.
 
 ::: {.callout-tip appearance="simple" collapse="true"}
 ## Danger In Dialogue: The Security Risks of Large Language Models
@@ -33,7 +33,7 @@ So in the run up to SQLBITS I released a trailer for my talk on the danger of LL
 
 
 
-Now as part of this work, I wanted to use the latest in image generation for research. Also as dyposian as it is, it's really kinda cool. Now the world has moved on since then with the rise of OpenAI's SORA. I however wanted to talk about the trial and error prompting that worked for me with VEO3.
+Now as part of this work, I wanted to use the latest in image generation for research. Also as dystopian as it is, it's really kinda cool. Now the world has moved on since then with the rise of OpenAI's SORA. I however wanted to talk about the trial and error prompting that worked for me with VEO3.
 
 
 

--- a/posts/welcome/index.qmd
+++ b/posts/welcome/index.qmd
@@ -12,4 +12,4 @@ Welcome back to a long overdue blog rebuild. I've attempted to rebuild this blog
 
 A lot has happened in the last few years but first I want to just get on with writing code and analysing data.
 
-If you're not familar yet, I run a (sometimes daily) Databricks Tips, tricks and hacks twitter account. That is followed by quite a few databricks people. I would recommend following it or signing up the even less frequent newsletter :)
+If you're not familiar yet, I run a (sometimes daily) Databricks Tips, tricks and hacks twitter account. That is followed by quite a few databricks people. I would recommend following it or signing up the even less frequent newsletter :)

--- a/posts/why-i-use-obsidian/index.qmd
+++ b/posts/why-i-use-obsidian/index.qmd
@@ -21,9 +21,9 @@ Here's what I actually use in Obsidian, and more importantly, what actually work
 
 I use Obsidian to structure my entire day. Every morning, I create a daily note with time blocks for focused work, meetings, and context switches. It's not magic. It's just having a single place where my schedule lives alongside my notes about what I'm working on.
 
-When I finish a meeting, I write notes directly into obsidian. When I need to remember what I was doing last Tuesday, I open that day's note. Simple, but effective.
+When I finish a meeting, I write notes directly into Obsidian. When I need to remember what I was doing last Tuesday, I open that day's note. Simple, but effective.
 
-This requires discipline and focus. If you know me well enough I kinda suck at focus but obsidian does force my hand. The tool doesn't make you organized. It just gives you a canvas to be organized on.
+This requires discipline and focus. If you know me well enough I kinda suck at focus but Obsidian does force my hand. The tool doesn't make you organized. It just gives you a canvas to be organized on.
 
 ![Daily note with time blocking](images/daily-note-screenshot.png)
 


### PR DESCRIPTION
Published posts: fix spelling errors (familar, obsidian, Juypter, Netify,
orchstration, strocastic, commuicate, dyposian, engineerign, etc.), grammar
fixes (your/you're, an/a, its/it's, who/whom), missing spaces after links,
broken empty links, missing heading formatting, and misplaced section heading
in obsidian-second-brain post.

Draft posts: fix invalid date format (2025-30-12 → 2025-12-30), fix category
typos (Large Langauge Models → Large Language Models, -sqlbits → sqlbits),
fix broken VEO3 cross-link in sql-bits-2025, fix leading space in title.

Series navigation: update "Part 3 (Coming Soon)" to actual links in the
Quarto blog series (Parts 1 and 2).

https://claude.ai/code/session_0132VDiaS2eigthysWLe1a56