### PR TITLE
Add scheduled weekly rebuilds and fix deployment condition

### DIFF
--- a/.github/workflows/render_quarto.yml
+++ b/.github/workflows/render_quarto.yml
@@ -9,6 +9,10 @@ on:
     types: [closed]
     branches:
       - main
+  schedule:
+    # Rebuild and deploy every Sunday at 19:00 UTC (7pm) so the site is
+    # rebuilt with the latest Quarto release and avoids dependency drift.
+    - cron: '0 19 * * 0'
 
 jobs:
   render_site:
@@ -38,7 +42,7 @@ jobs:
   
   deploy_to_azure_static_webapp:
     needs: render_site
-    if: success() && github.event.ref == 'refs/heads/main'
+    if: success() && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     name: Deploy to Azure App Service
     steps:

--- a/.github/workflows/render_quarto.yml
+++ b/.github/workflows/render_quarto.yml
@@ -10,8 +10,6 @@ on:
     branches:
       - main
   schedule:
-    # Rebuild and deploy every Sunday at 19:00 UTC (7pm) so the site is
-    # rebuilt with the latest Quarto release and avoids dependency drift.
     - cron: '0 19 * * 0'
 
 jobs:


### PR DESCRIPTION
## Summary
This PR adds scheduled weekly rebuilds of the site and fixes a bug in the deployment condition that was preventing deployments from scheduled runs.

## Key Changes
- **Add scheduled weekly rebuilds**: Configured a cron job to rebuild and deploy the site every Sunday at 19:00 UTC. This ensures the site stays up-to-date with the latest Quarto releases and prevents dependency drift.
- **Fix deployment condition**: Changed `github.event.ref` to `github.ref` in the deployment job's conditional. The `github.event.ref` variable is only available for certain event types (like pull requests), causing scheduled runs to fail the deployment step even when the build succeeded.

## Implementation Details
The scheduled rebuild uses a standard cron expression (`0 19 * * 0`) that runs weekly on Sundays. The deployment condition fix ensures that both push events and scheduled runs can properly evaluate the branch reference, allowing the site to deploy from scheduled builds on the main branch.

https://claude.ai/code/session_01KbWwR53yLSRTNj4Y2KJ2Uu